### PR TITLE
[README] Fixed build status in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 django-netjsongraph
 ===================
 
-.. image:: https://travis-ci.org/netjson/django-netjsongraph.svg
-   :target: https://travis-ci.org/netjson/django-netjsongraph
+.. image:: https://travis-ci.org/openwisp/django-netjsongraph.svg
+   :target: https://travis-ci.org/openwisp/django-netjsongraph
 
 .. image:: https://coveralls.io/repos/netjson/django-netjsongraph/badge.svg
   :target: https://coveralls.io/r/netjson/django-netjsongraph


### PR DESCRIPTION
Travis for some reason no longer support this url: https://travis-ci.org/netjson/django-netjsongraph
so I changed this url in `README`