### PR TITLE
[ci] Remove deprecated sudo Travis key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 dist: xenial
 language: python
-sudo: false
 cache: pip
 
 python:


### PR DESCRIPTION
This pull request removes reference to deprecated Travis CI `sudo: true`, as per https://config.travis-ci.com/explore.
Google Code-in Link: https://codein.withgoogle.com/tasks/4719920173023232
This is Code-in user aaPle.

