### PR TITLE
[tests] Mocked time library in tests #84

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 coveralls
 responses
+freezegun
 openwisp-utils[qa]>=0.2.1


### PR DESCRIPTION
Mocked out time in time-aware test cases using freezegun library in order to make these tests more reliable and performant
Fixes #84