### PR TITLE
release 0.6.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,11 @@
 Changelog
 =========
 
-Version 0.6.2 [Unreleased]
+Version 0.6.2 [2020-03-19]
 --------------------------
 
-- Renamed api setting TOPOLOGY_RECEIVE_URLCONF -> TOPOLOGY_API_URLCONF
-- Renamed api setting TOPOLOGY_RECEIVE_BASEURL -> TOPOLOGY_API_BASEURL
+- Renamed api setting ``TOPOLOGY_RECEIVE_BASEURL`` -> ``TOPOLOGY_API_BASEURL``
+- Renamed api setting ``TOPOLOGY_RECEIVE_URLCONF`` -> ``TOPOLOGY_API_URLCONF``
 
 Version 0.6.1 [2020-02-26]
 --------------------------

--- a/README.rst
+++ b/README.rst
@@ -313,10 +313,11 @@ another module, example, ``myapp.urls``.
 | **default**: |   ``None``    |
 +--------------+---------------+
 
-If you have a seperate instanse of django-netjsongraph to
-which you want to point your receive url to, you can use
-this option to change the base of the url,
-example: ``https://mytopology.myapp.com``.
+If you have a seperate instanse of django-netjsongraph on a
+different domain, you can use this option to change the base
+of the url, this will enable you to point all the API urls to
+your django-netjsongraph API server's domain,
+example value: ``https://mytopology.myapp.com``.
 
 Overriding visualizer templates
 -------------------------------

--- a/django_netjsongraph/__init__.py
+++ b/django_netjsongraph/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 6, 1, 'final')
+VERSION = (0, 6, 2, 'final')
 __version__ = VERSION  # alias
 
 


### PR DESCRIPTION
Version 0.6.2 [2020-03-19]
--------------------------

- Renamed api setting ``TOPOLOGY_RECEIVE_BASEURL`` -> ``TOPOLOGY_API_BASEURL``
- Renamed api setting ``TOPOLOGY_RECEIVE_URLCONF`` -> ``TOPOLOGY_API_URLCONF``