### PR TITLE
[tests] Use catch_signal from openwisp-utils

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 coveralls
 responses
 freezegun
-openwisp-utils[qa]>=0.4.1
+openwisp-utils[qa]>=0.4.5


### PR DESCRIPTION
Used `catch_signal` in tests though temporarily installed `openwisp-utils` from GitHub repository until 0.4.5 release.